### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/node/node_modules/jsftp/node_modules/event-stream/node_modules/map-stream/readme.markdown
+++ b/node/node_modules/jsftp/node_modules/event-stream/node_modules/map-stream/readme.markdown
@@ -2,7 +2,7 @@
 
 Refactored out of [event-stream](https://github.com/dominictarr/event-stream)
 
-##map (asyncFunction[, options])
+## map (asyncFunction[, options])
 
 Create a through stream from an asyncronous function.  
 
@@ -32,6 +32,6 @@ Each map MUST call the callback. It may callback with data, with an error or wit
 >
 >Also, if the callback is called more than once, every call but the first will be ignored.
 
-##Options 
+## Options 
 
  * `failures` - `boolean` continue mapping even if error occured. On error `map-stream` will emit `failure` event. (default: `false`)

--- a/node/node_modules/jsftp/node_modules/event-stream/node_modules/through/readme.markdown
+++ b/node/node_modules/jsftp/node_modules/event-stream/node_modules/through/readme.markdown
@@ -1,4 +1,4 @@
-#through
+# through
 
 [![build status](https://secure.travis-ci.org/dominictarr/through.png)](http://travis-ci.org/dominictarr/through)
 [![testling badge](https://ci.testling.com/dominictarr/through.png)](https://ci.testling.com/dominictarr/through)

--- a/node/node_modules/request/CHANGELOG.md
+++ b/node/node_modules/request/CHANGELOG.md
@@ -169,7 +169,8 @@
 - [#1687](https://github.com/request/request/pull/1687) Fix caseless bug - content-type not being set for multipart/form-data (@simov, @garymathews)
 
 ### v2.59.0 (2015/07/20)
-- [#1671](https://github.com/request/request/pull/1671) Add tests and docs for using the agent, agentClass, agentOptions and forever options. Forever option defaults to using http(s).Agent in node 0.12+ (@simov)
+- [#1671](https://github.com/request/request/pull/1671) Add tests and docs for using the agent, agentClass, agentOptions and forever options.
+ Forever option defaults to using http(s).Agent in node 0.12+ (@simov)
 - [#1679](https://github.com/request/request/pull/1679) Fix - do not remove OAuth param when using OAuth realm (@simov, @jhalickman)
 - [#1668](https://github.com/request/request/pull/1668) updated dependencies (@deamme)
 - [#1656](https://github.com/request/request/pull/1656) Fix form method (@simov)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
